### PR TITLE
Github Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,21 @@
+name: Build
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-java@v3
+      with:
+        distribution: temurin
+        java-version: 11
+        cache: gradle
+    - run: |
+        chmod +x ./gradlew
+        ./gradlew :module:assembleRelease
+    - uses: actions/upload-artifact@v3
+      with:
+        name: zygisk-imgui-modmenu
+        path: out/magisk_module_release/

--- a/.theia/settings.json
+++ b/.theia/settings.json
@@ -1,0 +1,3 @@
+{
+    "java.configuration.updateBuildConfiguration": "automatic"
+}


### PR DESCRIPTION
Added github actions option for building modules.

- Go to the **Actions** tab.
- In the left sidebar, click the **Build** workflow.
- Above the list of workflow runs, select Run workflow.
- Wait for the action to complete and download the artifact.

Credits: @AKANoryx28